### PR TITLE
chore(release): realign manifest version to the tag line (1.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Full digital chip design pipeline — 16 plugins across 15 domains, from infrastructure setup through tape-out and firmware, with closed-loop verification↔RTL feedback.",
-    "version": "1.4.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.4.0] — Memory IP Design domain
+## [1.8.0] — Memory IP Design domain
 
 ### Added
 
@@ -14,7 +14,8 @@
 
 ### Changed
 
-- Counts bumped to **16 plugins / 17 skills / 16 agents / 14 design domains** across `marketplace.json`, `package.json` (→ `1.4.0`), `README.md`, `CLAUDE.md`, `docs/PIPELINE.md`, `docs/MASTER_INDEX.md`, `docs/INSTALL.md`, the Codex/Gemini/Copilot IDE headers, and `.github/workflows/release.yml`.
+- Counts bumped to **16 plugins / 17 skills / 16 agents / 14 design domains** across `marketplace.json`, `package.json`, `README.md`, `CLAUDE.md`, `docs/PIPELINE.md`, `docs/MASTER_INDEX.md`, `docs/INSTALL.md`, the Codex/Gemini/Copilot IDE headers, and `.github/workflows/release.yml`.
+- **Manifest version realigned to the release tag line.** `package.json` and `.claude-plugin/marketplace.json` had drifted to `1.3.0` while tags advanced to `v1.7.0`, and PR #71 bumped them to `1.4.0` — which matched neither the drift nor the tag line, and implied a `v1.4.0` tag after `v1.7.0`. Both now read `1.8.0`, the next tag for this MINOR change (new orchestrator domain, per `CONTRIBUTING.md`). The `npm-publish` job in `release.yml` stamps these fields from the tag at publish time, so the in-repo values are informational — but they should not contradict the tag they will be released under.
 - `validate.yml` count asserts 15 → 16 (agents/marketplace and `applyto-map.json`); `tests/test_distill.py` domain count 14 → 15.
 - `distill.py`, `tools/qor_trends.py`, `memory/README.md`, and `memory-keeper/SKILL.md` registered the new domain; `projected_repair_yield_pct` added to `HIGHER_IS_BETTER`.
 - Installers updated: `install.sh` and `install.ps1` (plugin list, dir map, `enabledPlugins`, OpenCode mode map, completion message) and `bin/install.mjs` (`OPENCODE_MODE_DISPLAY`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-chip-design-agents",
-  "version": "1.4.0",
+  "version": "1.8.0",
   "description": "Full digital chip design pipeline — 16 Claude Code plugins across 15 domains, from infrastructure setup through tape-out and firmware, with closed-loop verification↔RTL feedback.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 📌 Description

Follow-up to #71. Sets `package.json` and `.claude-plugin/marketplace.json` to **`1.8.0`**, the correct next tag, replacing the `1.4.0` that #71 introduced.

## 🔗 Related Issue
Follows #71

## 🧪 Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement / refactor
- [ ] Documentation update

## 🧠 What Changed?

**The problem.** Releases are tag-driven — `release.yml` fires on `push: tags: v*.*.*` and takes the version from the tag itself (`VERSION=${GITHUB_REF#refs/tags/}`). The tag line is authoritative, and the latest is **v1.7.0**. But these two manifest fields had been frozen at `1.3.0`:

| Source | v1.5.12 | v1.6.0 | v1.7.0 | after #71 | this PR |
|---|---|---|---|---|---|
| git tag | 1.5.12 | 1.6.0 | 1.7.0 | — | **v1.8.0** (next) |
| `package.json` | 1.3.0 | 1.3.0 | 1.3.0 | 1.4.0 | **1.8.0** |
| `marketplace.json` | 1.3.0 | 1.3.0 | 1.3.0 | 1.4.0 | **1.8.0** |

#71 applied `CONTRIBUTING.md`'s MINOR rule to the stale `1.3.0` baseline and produced `1.4.0` — which matched neither the previous state nor the tag line, and implied a `v1.4.0` tag after `v1.7.0`.

**The fix.** Both fields now read `1.8.0` — MINOR from v1.7.0, since #71 added a new orchestrator domain (`chip-design-memory-ip`) and the change is additive. The CHANGELOG section is renamed `[1.4.0]` → `[1.8.0]` to match.

**Scope note on impact.** The `npm-publish` job in `release.yml` stamps `package.json`, `marketplace.json`, and every `plugins/*/.claude-plugin/plugin.json` from the tag at publish time, so what actually ships is always the tag version regardless of what is committed here. (That job was added after v1.7.0, which is why the drift went unnoticed.) These fields are therefore **informational in-repo** — this PR is about them not contradicting the tag they will be released under, not about changing what gets published.

`plugins/memory-ip/.claude-plugin/plugin.json` stays at `1.0.0`: it is a new plugin, and the publish job overwrites every `plugin.json` version from the tag anyway.

## 🔄 Affected Areas
- [ ] Agent logic
- [ ] Workflow orchestration
- [ ] Scripts / tooling
- [x] Documentation
- [x] Other: release metadata

## ⚙️ How to Test

1. `python -m pytest tests/ -q` → 45 passed
2. CI `validate.yml` runs on this PR — manifests, counts, and the Copilot key check are unaffected by a version-string change.
3. Confirm the intended next tag:
   ```bash
   git tag --sort=-v:refname | head -1      # v1.7.0
   python -c "import json; print(json.load(open('package.json'))['version'])"   # 1.8.0
   ```

## 📦 Outputs / Results

- `package.json` → `1.8.0`
- `.claude-plugin/marketplace.json` `metadata.version` → `1.8.0`
- CHANGELOG heading → `## [1.8.0] — Memory IP Design domain`

Verified: pytest 45 passed; marketplace/agent counts still 16; Copilot applyto key set still matches the skill inventory.

## ⚠️ Risks / Notes

- **No functional change.** Version strings only; no plugin, skill, orchestrator, or tooling behaviour is touched.
- **The next tag must be `v1.8.0`.** Tagging `v1.4.0` would go backwards from `v1.7.0` and, via the npm-publish job, attempt an npm downgrade.
- Longer term, the drift is worth preventing at source — either a CI assert that `package.json` version matches the latest tag, or dropping the in-repo values entirely since publish stamps them. Out of scope here.

## ✅ Checklist
- [x] Changes are scoped and minimal
- [x] Verified functionality manually or via tests
- [x] Documentation updated (CHANGELOG)
- [x] No breaking changes

## 📎 Additional Context

Per `CONTRIBUTING.md`: `MINOR (x.1.0) — new skill or orchestrator domain added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
